### PR TITLE
Woptim/overlap as inline option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Documentation regarding known issues.
 
+### Changed
+
+- Slurm allocation now uses command line option on project side (--overlap)
+  instead of environment variable (SLURM_OVERLAP) in shared CI.
+
 ### Fix
 
 - Wrong defaults in custom-variables file.

--- a/corona-build-and-test.yml
+++ b/corona-build-and-test.yml
@@ -40,8 +40,6 @@ stages:
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
     - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) ${RUBY_BUILD_AND_TEST_JOB_ALLOC} scripts/gitlab/build_and_test.sh
-  variables:
-    SLURM_OVERLAP: 1
 
 # In pre-build phase, allocate a node for builds.
 allocate_resources (on corona):

--- a/ruby-build-and-test.yml
+++ b/ruby-build-and-test.yml
@@ -33,8 +33,6 @@ stages:
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
     - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) ${RUBY_BUILD_AND_TEST_JOB_ALLOC} scripts/gitlab/build_and_test.sh
-  variables:
-    SLURM_OVERLAP: 1
 
 # In pre-build phase, allocate a node for builds.
 # TODO: make the resource configurable, not all projects will want the same.


### PR DESCRIPTION
RAJA is not using overlapping job sub-allocations in its CI because it performs poorly compared to sequential sub-allocations.

Radiuss-Shared-CI used to assume overlapping sub-allocations everywhere, setting SLURM_OVERLAP=1.
We remove this variable and assume projects will add "--overlap" to the job allocation options.

This branch requires change in Umpire to preserve current behavior.