### PR TITLE
[Woptim] Skip unnecessary project clone in status jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Next]
+
+### Added
+
+### Changed
+
+- Speed-up CI by not cloning the project in jobs only reporting to GitHub.
+
+### Fixed
+
 ## [v2022.09.0 - 2022-09-09]
 
 ### Added

--- a/corona-build-and-test.yml
+++ b/corona-build-and-test.yml
@@ -68,6 +68,8 @@ allocate_resources (on corona):
 
 status_pending:
   extends: [.on_corona]
+  variables:
+    GIT_STRATEGY: none
   stage: allocate_resources
   script:
     - export pipeline_status="pending"
@@ -95,6 +97,8 @@ release_resources (on corona):
 
 status_success:
   extends: [.on_corona]
+  variables:
+    GIT_STRATEGY: none
   stage: release_resources
   script:
     - export pipeline_status="success"
@@ -102,6 +106,8 @@ status_success:
 
 status_failure:
   extends: [.on_corona]
+  variables:
+    GIT_STRATEGY: none
   stage: release_resources
   script:
     - export pipeline_status="failure"

--- a/lassen-build-and-test.yml
+++ b/lassen-build-and-test.yml
@@ -46,6 +46,8 @@ stages:
 
 status_pending:
   extends: [.on_lassen]
+  variables:
+    GIT_STRATEGY: none
   stage: status_initiate
   script:
     - export pipeline_status="pending"
@@ -102,6 +104,8 @@ xl_16_1_1_12_gcc_8_3_1_cuda_11_0_2:
 
 status_success:
   extends: [.on_lassen]
+  variables:
+    GIT_STRATEGY: none
   stage: status_update
   script:
     - export pipeline_status="success"
@@ -110,6 +114,8 @@ status_success:
 
 status_failure:
   extends: [.on_lassen]
+  variables:
+    GIT_STRATEGY: none
   stage: status_update
   script:
     - export pipeline_status="failure"

--- a/ruby-build-and-test.yml
+++ b/ruby-build-and-test.yml
@@ -62,6 +62,8 @@ allocate_resources (on ruby):
 
 status_pending:
   extends: [.on_ruby]
+  variables:
+    GIT_STRATEGY: none
   stage: allocate_resources
   script:
     - export pipeline_status="pending"
@@ -107,6 +109,8 @@ release_resources (on ruby):
 
 status_success:
   extends: [.on_ruby]
+  variables:
+    GIT_STRATEGY: none
   stage: release_resources
   script:
     - export pipeline_status="success"
@@ -115,6 +119,8 @@ status_success:
 
 status_failure:
   extends: [.on_ruby]
+  variables:
+    GIT_STRATEGY: none
   stage: release_resources
   script:
     - export pipeline_status="failure"


### PR DESCRIPTION
A basic optimization: GitHub reporting jobs do not need a clone of the project to work. So we skip that in the job setup.

This should save some time in all projects, especially the large ones.