### PR TITLE
[Woptim] skip machine when down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Added
+- A job that test whether the machine is up, and reports the failure to GitHub otherwise.
+
+### Changed
+
+### Fixed
+
 ## [v2022.09.0 - 2022-09-09]
 
 ### Added

--- a/corona-build-and-test.yml
+++ b/corona-build-and-test.yml
@@ -6,6 +6,7 @@
 ##############################################################################
 
 stages:
+  - is-machine-up
   - allocate_resources
   - build_and_test
   - release_resources
@@ -34,6 +35,23 @@ stages:
       when: on_failure
     # A true statement is expected to allow jobs to run. Here is the default.
     - when: on_success
+
+is-machine-up-check:
+  stage: is-machine-up
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      if [[ $(jq '.corona.total_nodes_up' /usr/global/tools/lorenz/data/loginnodeStatus) == 0 ]]
+      then
+        echo -e "\e[31mNo node available on Corona\e[0m"
+        curl --url "https://api.github.com/repos/LLNL/${CI_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+             --header 'Content-Type: application/json' \
+             --header "authorization: Bearer ${GITHUB_TOKEN}" \
+             --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab Corona Down\", \"context\": \"ci/gitlab/corona\" }"
+        exit 1
+      fi
 
 .status_report: &status_report
     - export context="corona"

--- a/lassen-build-and-test.yml
+++ b/lassen-build-and-test.yml
@@ -6,6 +6,7 @@
 ##############################################################################
 
 stages:
+  - is-machine-up
   - status_initiate
   - build_and_test
   - status_update
@@ -29,6 +30,23 @@ stages:
       when: on_failure
     # A true statement is expected to allow jobs to run. Here is the default.
     - when: on_success
+
+is-machine-up-check:
+  stage: is-machine-up
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      if [[ $(jq '.lassen.total_nodes_up' /usr/global/tools/lorenz/data/loginnodeStatus) == 0 ]]
+      then
+        echo -e "\e[31mNo node available on Lassen\e[0m"
+        curl --url "https://api.github.com/repos/LLNL/${CI_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+             --header 'Content-Type: application/json' \
+             --header "authorization: Bearer ${GITHUB_TOKEN}" \
+             --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab Lassen Down\", \"context\": \"ci/gitlab/lassen\" }"
+        exit 1
+      fi
 
 .status_report: &status_report
     - export context="lassen"

--- a/ruby-build-and-test.yml
+++ b/ruby-build-and-test.yml
@@ -6,6 +6,7 @@
 ##############################################################################
 
 stages:
+  - is-machine-up
   - allocate_resources
   - build_and_test
   - release_resources
@@ -32,6 +33,23 @@ stages:
       when: on_failure
     # A true statement is expected to allow jobs to run. Here is the default.
     - when: on_success
+
+is-machine-up-check:
+  stage: is-machine-up
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      if [[ $(jq '.ruby.total_nodes_up' /usr/global/tools/lorenz/data/loginnodeStatus) == 0 ]]
+      then
+        echo -e "\e[31mNo node available on Ruby\e[0m"
+        curl --url "https://api.github.com/repos/LLNL/${CI_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+             --header 'Content-Type: application/json' \
+             --header "authorization: Bearer ${GITHUB_TOKEN}" \
+             --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab Ruby Down\", \"context\": \"ci/gitlab/ruby\" }"
+        exit 1
+      fi
 
 .status_report: &status_report
     - export context="ruby"


### PR DESCRIPTION
Long wanted feature:

We add a job at the beginning of each child pipeline (which correspond to one machine) that test whether the machine is up.

A preview: https://lc.llnl.gov/gitlab/radiuss/Umpire/-/pipelines/225528

- If the machine is up, the pipeline continues as usual.
- If the machine is down, the pipeline is interrupted, and a report is sent to GitHub: generate a specific status in the PR telling which machine caused the CI to fail.

With this, any project using radiuss shared ci benefits from the feature by default. I think it’s a great improvement, especially with the GitHub report.

@davidbeckingsale @rhornung67 Is it satisfying ? Do you see any drawback regarding making this a default feature ?