### PR TITLE
New feature: do not run on draft PRs.

### DIFF
--- a/customization/gitlab-ci.yml
+++ b/customization/gitlab-ci.yml
@@ -60,9 +60,10 @@ stages:
     forward:
       pipeline_variables: true
 
-# pipelines subscribed by the project
 include:
-  - local: .gitlab/subscribed-pipelines.yml
+  # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
     ref: v2022.09.0
     file: 'preliminary-ignore-draft-pr.yml'
+  # pipelines subscribed by the project
+  - local: .gitlab/subscribed-pipelines.yml

--- a/customization/gitlab-ci.yml
+++ b/customization/gitlab-ci.yml
@@ -65,4 +65,4 @@ include:
   - local: .gitlab/subscribed-pipelines.yml
   - project: 'radiuss/radiuss-shared-ci'
     ref: v2022.09.0
-    file: 'preliminary-should-we-test.yml'
+    file: 'preliminary-ignore-draft-pr.yml'

--- a/customization/gitlab-ci.yml
+++ b/customization/gitlab-ci.yml
@@ -24,6 +24,9 @@
 
 # We define the following GitLab pipeline variables:
 variables:
+# Identify the corresponding GitHub repository.
+  GITHUB_PROJECT_NAME: "..."
+  GITHUB_PROJECT_ORG: "..."
 # Use an LLNL service user to run CI. This prevents from running pipelines as
 # an actual user.
   LLNL_SERVICE_USER: ""
@@ -60,3 +63,6 @@ stages:
 # pipelines subscribed by the project
 include:
   - local: .gitlab/subscribed-pipelines.yml
+  - project: 'radiuss/radiuss-shared-ci'
+    ref: v2022.09.0
+    file: 'preliminary-should-we-test.yml'

--- a/preliminary-ignore-draft-pr.yml
+++ b/preliminary-ignore-draft-pr.yml
@@ -13,7 +13,7 @@
 
 # This job should fail if we don’t want the pipeline to run.
 # Here, we make sure the pipeline fails if the PR is a draft.
-should-we-test:
+ignore-draft-pr:
   stage: .pre
   tags: [shell, oslic]
   variables:

--- a/preliminary-ignore-draft-pr.yml
+++ b/preliminary-ignore-draft-pr.yml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
+# This file is optional, only include it in your CI (see
+# customization/gitlab-ci.yml) if you want to skip the CI on draft branches.
+
 # Requirements:
 # The following variables must be defined:
 # - GITHUB_TOKEN (granted in radiuss group)

--- a/preliminary-should-we-test.yml
+++ b/preliminary-should-we-test.yml
@@ -1,0 +1,48 @@
+###############################################################################
+# Copyright (c) 2022, Lawrence Livermore National Security, LLC and RADIUSS
+# project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+# Requirements:
+# The following variables must be defined:
+# - GITHUB_TOKEN (granted in radiuss group)
+# - GITHUB_PROJECT_NAME
+# - GITHUB_PROJECT_ORG
+
+# This job should fail if we don’t want the pipeline to run.
+# Here, we make sure the pipeline fails if the PR is a draft.
+should-we-test:
+  stage: .pre
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      curl --header "authorization: Bearer ${GITHUB_TOKEN}" -X POST -d " \
+      { \
+        \"query\": \"query { \
+                             repository(name: \\\"${GITHUB_PROJECT_NAME}\\\", owner: \\\"${GITHUB_PROJECT_ORG}\\\") { \
+                               pullRequests(last: 1, headRefName: \\\"${CI_COMMIT_REF_NAME}\\\") { \
+                                 nodes { \
+                                   number, \
+                                   isDraft \
+                                 } \
+                               } \
+                             } \
+                          }\" \
+      } \
+      " https://api.github.com/graphql > data.json 2> /dev/null
+      if $(jq '.data.repository.pullRequests.nodes[].isDraft' data.json)
+      then
+        curl --url "https://api.github.com/repos/${GITHUB_PROJECT_ORG}/${GITHUB_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+             --header 'Content-Type: application/json' \
+             --header "authorization: Bearer ${GITHUB_TOKEN}" \
+             --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab: Skipped Draft PR\", \"context\": \"ci/gitlab/skipped-draft-pr\" }"
+        exit 1
+      fi
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: never
+    - when: on_success


### PR DESCRIPTION
This branch adds GitLab CI code to allow projects to prevent CI from running on draft PRs.

As long as the PR is "draft" the test on GitLab will report a failure "Skipped Draft PR". When the PR is marked ready for review (draft off), the next commit will be tested).

This is working great, and only requires minimal additions on the project side.

Notes:
- This is an opt-in feature: this will only be active in the project includes the file `preliminary-ignore-draft-pr`.
- Triggering the pipeline manually in GitLab will work around this and effectively run the tests.
- There is no straightforward way to manually trigger tests of a draft PR from GitHub.

Here is a preview: https://github.com/LLNL/RAJA/pull/1347