### PR TITLE
Attempt to share flux allocation

### DIFF
--- a/corona-build-and-test.yml
+++ b/corona-build-and-test.yml
@@ -66,11 +66,10 @@ stages:
       echo ${ALLOC_NAME}
       URI=$(flux jobs -o "{uri} {name}" | grep ${ALLOC_NAME} | awk '{print $1}') || echo "Empty URI"
       echo ${URI}
-      if [[ -n "$URI" ]]; then export FLUX_URI=$URI; fi
     # Print a reproducer
     - *print_corona_reproducer
     # The actual launch command
-    - flux mini run ${CORONA_BUILD_AND_TEST_JOB_ALLOC} ${BUILD_AND_TEST_CMD}
+    - $( [[ -n "${URI}" ]] && echo "flux proxy ${URI}" ) flux mini run ${CORONA_BUILD_AND_TEST_JOB_ALLOC} ${BUILD_AND_TEST_CMD}
 
 ##############################################################################
 # JOBS
@@ -101,7 +100,7 @@ allocate_resources (on corona):
     - |
       set -x
       echo "Shared allocation disabled: runs slowly, needs a fix"
-      #flux mini batch ${CORONA_BUILD_AND_TEST_SHARED_ALLOC} --job-name=${ALLOC_NAME} --wrap sleep inf
+      flux --parent mini alloc ${CORONA_BUILD_AND_TEST_SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
 
 status_pending:
   extends: [.on_corona]
@@ -129,8 +128,8 @@ release_resources (on corona):
     - |
       set -x
       echo "Shared allocation disabled: runs slowly, needs a fix"
-      #export JOBID=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
-      #([[ -n "${JOBID}" ]] && flux job kill ${JOBID})
+      export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
+      ([[ -n "${URI}" ]] && flux job kill ${URI})
 
 status_success:
   extends: [.on_corona]

--- a/customization/custom-jobs-and-variables.yml
+++ b/customization/custom-jobs-and-variables.yml
@@ -24,7 +24,7 @@ variables:
 
 # Corona
 # Arguments for top level allocation
-  CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--time-limit=15m --nodes=1"
+  CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --time-limit=15m --nodes=1"
 # Arguments for job level allocation
   CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=10m --nodes=1"
 # Project specific variants for corona
@@ -34,7 +34,7 @@ variables:
 
 # Tioga
 # Arguments for top level allocation
-  TIOGA_BUILD_AND_TEST_SHARED_ALLOC: "--time-limit=15m --nodes=1"
+  TIOGA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --time-limit=15m --nodes=1"
 # Arguments for job level allocation
   TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=10m --nodes=1"
 # Project specific variants for tioga

--- a/tioga-build-and-test.yml
+++ b/tioga-build-and-test.yml
@@ -66,11 +66,10 @@ stages:
       echo ${ALLOC_NAME}
       URI=$(flux jobs -o "{uri} {name}" | grep ${ALLOC_NAME} | awk '{print $1}') || echo "Empty URI"
       echo ${URI}
-      if [[ -n "$URI" ]]; then export FLUX_URI=$URI; fi
     # Print a reproducer
     - *print_tioga_reproducer
     # The actual launch command
-    - flux mini run ${TIOGA_BUILD_AND_TEST_JOB_ALLOC} ${BUILD_AND_TEST_CMD}
+    - $( [[ -n "${URI}" ]] && echo "flux proxy ${URI}" ) flux mini run ${TIOGA_BUILD_AND_TEST_JOB_ALLOC} ${BUILD_AND_TEST_CMD}
 
 ##############################################################################
 # JOBS
@@ -101,7 +100,7 @@ allocate_resources:
     - |
       set -x
       echo "Shared allocation disabled: runs slowly, needs a fix"
-      #flux mini batch ${TIOGA_BUILD_AND_TEST_SHARED_ALLOC} --job-name=${ALLOC_NAME} --wrap sleep inf
+      flux --parent mini alloc ${TIOGA_BUILD_AND_TEST_SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
 
 status_pending:
   extends: .on_tioga
@@ -129,8 +128,8 @@ release_resources:
     - |
       set -x
       echo "Shared allocation disabled: runs slowly, needs a fix"
-      #export JOBID=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
-      #([[ -n "${JOBID}" ]] && flux job kill ${JOBID})
+      export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
+      ([[ -n "${URI}" ]] && flux job kill ${URI})
 
 status_success:
   extends: .on_tioga


### PR DESCRIPTION
This is an attempt at sharing the flux allocation among jobs.

This allows several things:
- Allocate resource only once. Note: flux allocations have been fast _so far_.
- Decide whether or not to run jobs concurrently on allocated jobs (useful when we have many small builds).
- Run all the tests on the same node: useful for performance analysis.