### PR TITLE
[Woptim] draft filter fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2023.12.0 - ....-..-.. ]
+## [v2023.12.3 - 2024-03-06 ]
+
+- Fix draft PR filter mechanism: override failures with a success status when
+  PR is not a draft anymore, support pipelines running on tags.
+
+## [v2023.12.2 - 2024-02-12 ]
+
+- Fix reproducer logic: apply anchors to references migration everywhere
+
+## [v2023.12.1 - 2023-12-19 ]
+
+- Fix reproducer logic: move from YAML anchors to YAML references
+
+## [v2023.12.0 - 2023-12-11 ]
 
 - Update flux commands to allow controlled overlapping and MPI tests
 - BREAKING: Update reproducer logic to allow for customization. The reproducer

--- a/utilities/preliminary-ignore-draft-pr.yml
+++ b/utilities/preliminary-ignore-draft-pr.yml
@@ -36,7 +36,8 @@ ignore-draft-pr:
       description="GitLab: Pull Request vetted for testing"
       status="success"
       return_code=0
-      if [[ ! "${CI_COMMIT_BRANCH}" =~ ${always_run_pattern} ]];
+      # CI_COMMIT_BRANCH is only empty for tags, we always run CI on tags.
+      if [[ ! "${CI_COMMIT_BRANCH}" =~ ${always_run_pattern} && -n "${CI_COMMIT_BRANCH}" ]];
       then
           curl --header "authorization: Bearer ${GITHUB_TOKEN}" -X POST -d " \
           { \

--- a/utilities/preliminary-ignore-draft-pr.yml
+++ b/utilities/preliminary-ignore-draft-pr.yml
@@ -27,13 +27,22 @@ ignore-draft-pr:
       # Note: the pattern can be overridden setting ALWAYS_RUN_PATTERN.
       always_run_pattern="${ALWAYS_RUN_PATTERN:-"^develop$|^main$|^master$|^v[0-9.]*$"}"
       # If the current branch is not in the always run pattern
-      if [[ ! "${CI_COMMIT_REF_NAME}" =~ ${always_run_pattern} ]];
+      echo ""
+      echo "### Draft filter parameters ###"
+      echo "# CI_COMMIT_BRANCH = ${CI_COMMIT_BRANCH}"
+      echo "# ALWAYS_RUN_PATTERN = ${ALWAYS_RUN_PATTERN}"
+      echo "# CI_COMMIT_SHA = ${CI_COMMIT_SHA}"
+      echo ""
+      description="GitLab: Pull Request vetted for testing"
+      status="success"
+      return_code=0
+      if [[ ! "${CI_COMMIT_BRANCH}" =~ ${always_run_pattern} ]];
       then
           curl --header "authorization: Bearer ${GITHUB_TOKEN}" -X POST -d " \
           { \
             \"query\": \"query { \
                                  repository(name: \\\"${GITHUB_PROJECT_NAME}\\\", owner: \\\"${GITHUB_PROJECT_ORG}\\\") { \
-                                   pullRequests(last: 1, headRefName: \\\"${CI_COMMIT_REF_NAME}\\\") { \
+                                   pullRequests(last: 1, headRefName: \\\"${CI_COMMIT_BRANCH}\\\") { \
                                      nodes { \
                                        number, \
                                        isDraft \
@@ -45,13 +54,16 @@ ignore-draft-pr:
           " https://api.github.com/graphql > data.json 2> /dev/null
           if $(jq '.data.repository.pullRequests.nodes[].isDraft' data.json)
           then
-            curl --url "https://api.github.com/repos/${GITHUB_PROJECT_ORG}/${GITHUB_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
-                 --header 'Content-Type: application/json' \
-                 --header "authorization: Bearer ${GITHUB_TOKEN}" \
-                 --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab: Skipped Draft PR\", \"context\": \"ci/gitlab/skipped-draft-pr\" }"
-            exit 1
+              description="GitLab: skipped draft Pull Request"
+              status="failure"
+              return_code=1
           fi
       fi
+      curl --url "https://api.github.com/repos/${GITHUB_PROJECT_ORG}/${GITHUB_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+           --header 'Content-Type: application/json' \
+           --header "authorization: Bearer ${GITHUB_TOKEN}" \
+           --data "{ \"state\": \"${status}\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"${description}\", \"context\": \"ci/gitlab/skipped-draft-pr\" }"
+      exit ${return_code}
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
       when: never


### PR DESCRIPTION
This PR fixes 2 bugs in the filtering of draft PRs when synced with GitLab.

- PRs initially seen as "draft" had a remaining failure status due to the draft test only reporting failures. The draft test now reports success too. The check will show as successful as soon as the PR pipeline runs and the PR is not a draft anymore.

- When a pipeline was generated out of a tag, the test was not able to retrieve a PR and interpreted it as a draft. Now pipelines with always run on tags.