### PR TITLE
v2024.12.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [v2024.12.0 - 2024-12-19 ]
 
+- Add new utility that prevent to run CI on branches that are not PRs.
 - Document sharing jobs (e.g. GH llnl/radiuss-spack-configs/gitlab/radiuss-jobs).
 - Point at GitLab documentation for mirroring setup.
 - Improve support for complex commands passed to scheduler using xargs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2024.12.0 - 2024-12-19 ]
+
+- Document sharing jobs (e.g. GH llnl/radiuss-spack-configs/gitlab/radiuss-jobs).
+- Point at GitLab documentation for mirroring setup.
+- Improve support for complex commands passed to scheduler using xargs.
+
+## [v2024.07.0 - 2024-07-15 ]
+
+- Fix documentation template.
+- Do not report child pipeline statuses to github (now handled by GitLab directly).
+
 ## [v2024.06.0 - 2024-06-07 ]
 
 - Releasing an allocation will not fail anymore when the allocation did not

--- a/customization/custom-jobs-and-variables.yml
+++ b/customization/custom-jobs-and-variables.yml
@@ -60,3 +60,12 @@ variables:
 .custom_job:
   variables:
     JOB_TEMPLATE_CANNOT_BE_EMPTY: "True"
+
+# This is how we print the variables necessary to reproduce a job. In
+# particular, we put here variables that are common for all the machines
+# (only values differ).
+.reproducer_vars:
+  script:
+    - |
+      echo -e "# Define project specific variables here if any."
+      #echo -e "export <CUSTOM_VAR>=\"${<CUSTOM_VAR>}\""

--- a/customization/gitlab-ci.yml
+++ b/customization/gitlab-ci.yml
@@ -73,15 +73,16 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2023.09.0'
+        ref: 'v2024.07.0'
         file: 'pipelines/${CI_MACHINE}.yml'
       # Add your jobs
       # you can use a local file
       - local: '.gitlab/jobs/${CI_MACHINE}.yml'
-      # or a file generated in the previous steps
+      ## [Shared jobs scenario]
+      ## or a file generated in the previous steps
+      ## (See Umpire CI setup for an example).
       # - artifact: '${CI_MACHINE}-jobs.yml'
       #   job: 'generate-job-file'
-      # (See Umpire CI setup for an example).
     strategy: depend
     forward:
       pipeline_variables: true
@@ -92,7 +93,7 @@ include:
     file: 'id_tokens.yml'
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'v2023.09.0'
+    ref: 'v2024.07.0'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/customization/gitlab-ci.yml
+++ b/customization/gitlab-ci.yml
@@ -73,7 +73,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2024.07.0'
+        ref: 'v2024.12.0'
         file: 'pipelines/${CI_MACHINE}.yml'
       # Add your jobs
       # you can use a local file
@@ -93,7 +93,7 @@ include:
     file: 'id_tokens.yml'
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'v2024.07.0'
+    ref: 'v2024.12.0'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/customization/jobs/<machine>.yml
+++ b/customization/jobs/<machine>.yml
@@ -14,9 +14,7 @@
 # reproducer to exactly reproduce the CI build.
 .<machine>_reproducer_vars:
   script:
-    - |
-      echo -e "# Define project specific variables here if any."
-      #echo -e "export <CUSTOM_VAR>=\"${<CUSTOM_VAR>}\""
+    - !reference [.reproducer_vars, script]
 
 # With GitLab CI, included files cannot be empty.
 # TODO: remove when you have at least on job defined.

--- a/customization/subscribed-pipelines.yml
+++ b/customization/subscribed-pipelines.yml
@@ -85,7 +85,7 @@ poodle-build-and-test:
   needs: [poodle-up-check]
   ## [Shared jobs scenario]
   ## (See Umpire CI setup for an example).
-  #needs: [ruby-up-check, generate-job-lists]
+  #needs: [poodle-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # CORONA
@@ -100,7 +100,7 @@ corona-build-and-test:
   needs: [corona-up-check]
   ## [Shared jobs scenario]
   ## (See Umpire CI setup for an example).
-  #needs: [ruby-up-check, generate-job-lists]
+  #needs: [corona-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # TIOGA
@@ -115,7 +115,7 @@ tioga-build-and-test:
   needs: [tioga-up-check]
   ## [Shared jobs scenario]
   ## (See Umpire CI setup for an example).
-  #needs: [ruby-up-check, generate-job-lists]
+  #needs: [tioga-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # LASSEN
@@ -130,7 +130,7 @@ lassen-build-and-test:
   needs: [lassen-up-check]
   ## [Shared jobs scenario]
   ## (See Umpire CI setup for an example).
-  #needs: [ruby-up-check, generate-job-lists]
+  #needs: [lassen-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 

--- a/customization/subscribed-pipelines.yml
+++ b/customization/subscribed-pipelines.yml
@@ -24,6 +24,35 @@
         exit 1
       fi
 
+## [Shared jobs scenario]
+## The job list can be imported from the .gitlab/jobs/<machine>.yml file, which
+## is the default behavior of RADIUSS Shared CI. Or the list can be generated,
+## allowing more complex setups, like sharing a list of jobs like we do with
+## RADIUSS Spack Configs. Below is an example # job that concatenates jobs from
+## two sources.
+## (See Umpire CI setup for an example).
+#
+## One job to generate the job list for all the subpipelines
+#generate-job-lists:
+#  stage: prerequisites
+#  tags: [shell, oslic]
+#  variables:
+#    LOCAL_JOBS_PATH: ".gitlab/jobs"
+#    REMOTE_JOBS_PATH: "<remote/jobs/path>"
+#  script:
+#    - cat ${LOCAL_JOBS_PATH}/ruby.yml ${REMOTE_JOBS_PATH}/ruby.yml > ruby-jobs.yml
+#    - cat ${LOCAL_JOBS_PATH}/poodle.yml ${REMOTE_JOBS_PATH}/poodle.yml > poodle-jobs.yml
+#    - cat ${LOCAL_JOBS_PATH}/lassen.yml ${REMOTE_JOBS_PATH}/lassen.yml > lassen-jobs.yml
+#    - cat ${LOCAL_JOBS_PATH}/corona.yml ${REMOTE_JOBS_PATH}/corona.yml > corona-jobs.yml
+#    - cat ${LOCAL_JOBS_PATH}/tioga.yml ${REMOTE_JOBS_PATH}/tioga.yml > tioga-jobs.yml
+#  artifacts:
+#    paths:
+#      - ruby-jobs.yml
+#      - poodle-jobs.yml
+#      - lassen-jobs.yml
+#      - corona-jobs.yml
+#      - tioga-jobs.yml
+
 ###
 # Trigger a build-and-test pipeline for a machine.
 # Comment the jobs for machines you don’t need.
@@ -39,6 +68,9 @@ ruby-build-and-test:
   variables:
     CI_MACHINE: "ruby"
   needs: [ruby-up-check]
+  ## [Shared jobs scenario]
+  ## (See Umpire CI setup for an example).
+  #needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # POODLE
@@ -51,6 +83,9 @@ poodle-build-and-test:
   variables:
     CI_MACHINE: "poodle"
   needs: [poodle-up-check]
+  ## [Shared jobs scenario]
+  ## (See Umpire CI setup for an example).
+  #needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # CORONA
@@ -63,6 +98,9 @@ corona-build-and-test:
   variables:
     CI_MACHINE: "corona"
   needs: [corona-up-check]
+  ## [Shared jobs scenario]
+  ## (See Umpire CI setup for an example).
+  #needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # TIOGA
@@ -75,6 +113,9 @@ tioga-build-and-test:
   variables:
     CI_MACHINE: "tioga"
   needs: [tioga-up-check]
+  ## [Shared jobs scenario]
+  ## (See Umpire CI setup for an example).
+  #needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # LASSEN
@@ -87,6 +128,9 @@ lassen-build-and-test:
   variables:
     CI_MACHINE: "lassen"
   needs: [lassen-up-check]
+  ## [Shared jobs scenario]
+  ## (See Umpire CI setup for an example).
+  #needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 

--- a/docs/sphinx/user_guide/setup_ci.rst
+++ b/docs/sphinx/user_guide/setup_ci.rst
@@ -1,5 +1,5 @@
 .. ##
-.. ## Copyright (c) 2022-2023, Lawrence Livermore National Security, LLC and
+.. ## Copyright (c) 2022-2024, Lawrence Livermore National Security, LLC and
 .. ## other RADIUSS Project Developers. See the top-level COPYRIGHT file for
 .. ## details.
 .. ##

--- a/docs/sphinx/user_guide/setup_ci.rst
+++ b/docs/sphinx/user_guide/setup_ci.rst
@@ -101,6 +101,9 @@ integrating the RADIUSS Shared CI infrastructure into your project.
    vim .gitlab/jobs/<machine>.yml
    # Add jobs or override some of the shared ones.
 
+   ### Mirroring Setup
+   https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html#connect-with-personal-access-token
+
    ### Non-RADIUSS projects
    open https://lc.llnl.gov/gitlab/<group>/<project>/-/settings/ci_cd
    # Set CI/CD variable GITHUB_TOKEN to hold token with repo:status
@@ -241,7 +244,7 @@ Add jobs
 --------
 
 We provide a template file to add jobs to each machine. You should create one
-file per machine using this template. These files may be place in your
+file per machine using this template. These files may be placed in your
 project's ``.gitlab/jobs`` subdirectory and named ``<machine>.yml``, where
 ``<machine>`` is the machine name. They are required as soon as the
 associated machine has been activated (uncommented) in the
@@ -263,15 +266,27 @@ duplicate the example job and complete it with the required information:
    same toolchains. See the dedicated How-To section for more details
    :ref:`import-shared-jobs`.
 
+Mirroring Setup
+---------------
+
+RADIUSS Shared CI is primarily intended for projects hosted on GitHub that need
+to run tests on LLNL Livermore Computing (LC) systems through the LC GitLab
+instance. GitLab provides a mirroring feature with GitHub integration that will
+automate the synchronisation of local source with the remote GitHub repository.
+
+The mirroring setup is described in detail in `GitLab documentation_`:
+
 Non-RADIUSS Projects
 --------------------
 
 RADIUSS Shared CI features a customized status report mechanism that reports to
-to GitHub the CI status of each sub-pipeline (one per machine).
+to GitHub when a machine is down, making it impossible to run the pipeline.
+This prevent users from having to connect to GitLab to find out.
 
-This feature requires the creation of a GitHub token with ``repo:status``
-permissions, and registering it as a CI/CD variable named ``GITHUB_TOKEN`` in
-the project (or the group) on GitLab.
+If your project hasn't been mirrored within the Radiuss group on LC GitLab,
+this feature will only work after you create a GitHub token with
+``repo:status`` permissions, and registering it as a CI/CD variable named
+``GITHUB_TOKEN`` in the project (or the group) on GitLab.
 
 Visit ``https://lc.llnl.gov/gitlab/<group>/<project>/-/settings/ci_cd`` to
 create the variable once the token has been generated on GitHub.
@@ -281,3 +296,4 @@ create the variable once the token has been generated on GitHub.
 .. _export jUnit test reports: https://github.com/LLNL/Umpire/blob/develop/.gitlab/custom-jobs-and-variables.yml
 .. _sharing spack configuration files: https://github.com/LLNL/radiuss-spack-configs
 .. _RADIUSS Spack Configs: https://radiuss-spack-configs.readthedocs.io/en/latest/index.html
+.. _GitLab documentation: https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html#connect-with-personal-access-token

--- a/docs/sphinx/user_guide/setup_ci.rst
+++ b/docs/sphinx/user_guide/setup_ci.rst
@@ -92,7 +92,7 @@ integrating the RADIUSS Shared CI infrastructure into your project.
    mkdir -p .gitlab/jobs
    cp ../radiuss-shared-ci/customization/subscribed-pipelines.yml .gitlab
    cp ../radiuss-shared-ci/customization/custom-jobs-and-variables.yml .gitlab
-   cp ../radiuss-shared-ci/jobs/\<machine\>.yml .gitlab/jobs/<machine>.yml
+   cp ../radiuss-shared-ci/customization/jobs/\<machine\>.yml .gitlab/jobs/<machine>.yml
    # You may use the <machine>.yml file as a starting point to add jobs.
    vim .gitlab/subscription-pipelines.yml
    # comment the jobs associted to <CI_MACHINE> you don't want.

--- a/pipelines/corona.yml
+++ b/pipelines/corona.yml
@@ -73,7 +73,7 @@ stages:
 
 .corona_job_command:
   script:
-    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${CORONA_JOB_ALLOC} ${JOB_CMD})
+    - ${PROXY} flux watch $( echo -e ${JOB_CMD} | xargs ${PROXY} flux batch -o output.stdout.type=kvs ${CORONA_JOB_ALLOC} )
 
 .job_on_corona:
   extends: [.custom_job, .on_corona]

--- a/pipelines/lassen.yml
+++ b/pipelines/lassen.yml
@@ -68,7 +68,7 @@ stages:
 
 .lassen_job_command:
   script:
-    - lalloc ${LASSEN_JOB_ALLOC} ${JOB_CMD}
+    - echo -e ${JOB_CMD} | xargs lalloc ${LASSEN_JOB_ALLOC}
 
 .job_on_lassen:
   extends: [.custom_job, .on_lassen]

--- a/pipelines/poodle.yml
+++ b/pipelines/poodle.yml
@@ -73,7 +73,7 @@ stages:
 
 .poodle_job_command:
   script:
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) ${POODLE_JOB_ALLOC} ${JOB_CMD}
+    - echo -e ${JOB_CMD} | xargs srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) ${POODLE_JOB_ALLOC}
 
 .job_on_poodle:
   extends: [.custom_job, .on_poodle]

--- a/pipelines/ruby.yml
+++ b/pipelines/ruby.yml
@@ -74,7 +74,7 @@ stages:
 
 .ruby_job_command:
   script:
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) ${RUBY_JOB_ALLOC} ${JOB_CMD}
+    - echo -e ${JOB_CMD} | xargs srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) ${RUBY_JOB_ALLOC}
 
 .job_on_ruby:
   extends: [.custom_job, .on_ruby]

--- a/pipelines/ruby.yml
+++ b/pipelines/ruby.yml
@@ -95,7 +95,6 @@ stages:
 # JOBS
 
 # In pre-build phase, allocate a node for builds.
-# TODO: make the resource configurable, not all projects will want the same.
 allocate_resources:
   variables:
     GIT_STRATEGY: none

--- a/pipelines/tioga.yml
+++ b/pipelines/tioga.yml
@@ -73,7 +73,7 @@ stages:
 
 .tioga_job_command:
   script:
-    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${TIOGA_JOB_ALLOC} ${JOB_CMD})
+    - ${PROXY} flux watch $( echo -e ${JOB_CMD} | xargs ${PROXY} flux batch -o output.stdout.type=kvs ${TIOGA_JOB_ALLOC} )
 
 .job_on_tioga:
   extends: [.custom_job, .on_tioga]

--- a/utilities/skip-branch-not-a-pr.yml
+++ b/utilities/skip-branch-not-a-pr.yml
@@ -1,0 +1,70 @@
+###############################################################################
+# Copyright (c) 2022-23, Lawrence Livermore National Security, LLC and RADIUSS
+# project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+# This file is optional, only include it in your CI (see
+# customization/gitlab-ci.yml) if you want to skip the CI on draft branches.
+
+# Requirements:
+# The following variables must be defined:
+# - GITHUB_TOKEN (granted in radiuss group)
+# - GITHUB_PROJECT_NAME
+# - GITHUB_PROJECT_ORG
+
+# This job should fail if we don’t want the pipeline to run.
+# Here, we make sure the pipeline fails if the branch is not a PR.
+ignore-branches-not-a-pr:
+  stage: .pre
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      # Create a pattern of branch names on which we always run.
+      # Note: the pattern can be overridden setting ALWAYS_RUN_PATTERN.
+      always_run_pattern="${ALWAYS_RUN_PATTERN:-"^develop$|^main$|^master$|^v[0-9.]*$"}"
+      # If the current branch is not in the always run pattern
+      echo ""
+      echo "### Draft filter parameters ###"
+      echo "# CI_COMMIT_BRANCH = ${CI_COMMIT_BRANCH}"
+      echo "# ALWAYS_RUN_PATTERN = ${ALWAYS_RUN_PATTERN}"
+      echo "# CI_COMMIT_SHA = ${CI_COMMIT_SHA}"
+      echo ""
+      description="GitLab: Pull Request vetted for testing"
+      status="success"
+      return_code=0
+      # CI_COMMIT_BRANCH is only empty for tags, we always run CI on tags.
+      if [[ ! "${CI_COMMIT_BRANCH}" =~ ${always_run_pattern} && -n "${CI_COMMIT_BRANCH}" ]];
+      then
+          curl --header "authorization: Bearer ${GITHUB_TOKEN}" -X POST -d " \
+          { \
+            \"query\": \"query { \
+                                 repository(name: \\\"${GITHUB_PROJECT_NAME}\\\", owner: \\\"${GITHUB_PROJECT_ORG}\\\") { \
+                                   pullRequests(last: 1, headRefName: \\\"${CI_COMMIT_BRANCH}\\\") { \
+                                     nodes { \
+                                       number \
+                                     } \
+                                   } \
+                                 } \
+                              }\" \
+          } \
+          " https://api.github.com/graphql > data.json 2> /dev/null
+          if $(jq '.data.repository.pullRequests.nodes[]' data.json)
+          then
+              description="GitLab: skipped branch not a Pull Request"
+              status="failure"
+              return_code=1
+          fi
+      fi
+      curl --url "https://api.github.com/repos/${GITHUB_PROJECT_ORG}/${GITHUB_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+           --header 'Content-Type: application/json' \
+           --header "authorization: Bearer ${GITHUB_TOKEN}" \
+           --data "{ \"state\": \"${status}\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"${description}\", \"context\": \"ci/gitlab/skipped-is-not-a-pr\" }"
+      exit ${return_code}
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: never
+    - when: on_success


### PR DESCRIPTION
- Document sharing jobs (e.g. GH llnl/radiuss-spack-configs/gitlab/radiuss-jobs).
- Point at GitLab documentation for mirroring setup.
- Improve support for complex commands passed to scheduler using xargs.
- Add new utility that prevent to run CI on branches that are not PRs.