### PR TITLE
Add a pipeline dedicated to performance runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2025.06.0 - XXXX-XX-XX ]
+
+- Add performance pipeline for any machine.
+
 ## [v2025.06.0 - 2024-07-16 ]
 
 - Add pipelines for Dane and Tuolumne.

--- a/customization/custom-jobs-and-variables.yml
+++ b/customization/custom-jobs-and-variables.yml
@@ -69,6 +69,13 @@ variables:
   variables:
     JOB_TEMPLATE_CANNOT_BE_EMPTY: "True"
 
+# Configuration shared by performance jobs specific to this project.
+# Not all configuration can be shared. Here projects can fine tune the
+# CI behavior.
+.perf_job:
+  variables:
+    JOB_TEMPLATE_CANNOT_BE_EMPTY: "True"
+
 # This is how we print the variables necessary to reproduce a job. In
 # particular, we put here variables that are common for all the machines
 # (only values differ).

--- a/customization/gitlab-ci.yml
+++ b/customization/gitlab-ci.yml
@@ -65,6 +65,7 @@ variables:
 stages:
   - prerequisites
   - build-and-test
+  - performance-measurements
 
 # Template for jobs triggering a build-and-test sub-pipeline:
 .build-and-test:
@@ -73,7 +74,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2025.06.0'
+        ref: 'v2025.07.0'
         file: 'pipelines/${CI_MACHINE}.yml'
       # Add your jobs
       # you can use a local file
@@ -87,13 +88,26 @@ stages:
     forward:
       pipeline_variables: true
 
+performance-measurements:
+  stage: performance-measurements
+  trigger:
+    include:
+      - local: '.gitlab/custom-jobs-and-variables.yml'
+      - project: 'radiuss/radiuss-shared-ci'
+        ref: 'v2025.07.0'
+        file: 'pipelines/performances.yml'
+      - local: '.gitlab/jobs/performances.yml'
+    strategy: depend
+    forward:
+      pipeline_variables: true
+
 include:
   # Sets ID tokens for every job using `default:`
   - project: 'lc-templates/id_tokens'
     file: 'id_tokens.yml'
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'v2025.06.0'
+    ref: 'v2025.07.0'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/pipelines/performances.yml
+++ b/pipelines/performances.yml
@@ -1,0 +1,93 @@
+##############################################################################
+# Copyright (c) 2025, Lawrence Livermore National Security, LLC and RADIUSS
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+# Sets ID tokens for every job using `default:`
+include:
+  - project: 'lc-templates/id_tokens'
+    file: 'id_tokens.yml'
+
+stages:
+  - perf-runs
+
+.perf_on_ruby:
+  extends: [.perf_job]
+  stage: perf-runs
+  tags:
+    - shell
+    - ruby
+  rules:
+    # Runs except if we explicitly deactivate ruby by variable.
+    - if: '$ON_RUBY == "OFF"'
+      when: never
+    - when: on_success
+  script:
+    - srun ${RUBY_PERF_ALLOC} ${JOB_CMD}
+
+.perf_on_dane:
+  extends: [.perf_job]
+  stage: perf-runs
+  tags:
+    - shell
+    - dane
+  rules:
+    - if: '$ON_DANE == "OFF"'
+      when: never
+    - when: on_success
+  script:
+    - srun ${DANE_PERF_ALLOC} ${JOB_CMD}
+
+.perf_on_corona:
+  extends: [.perf_job]
+  stage: perf-runs
+  tags:
+    - shell
+    - corona
+  rules:
+    - if: '$ON_CORONA == "OFF"'
+      when: never
+    - when: on_success
+  script:
+    - srun ${CORONA_PERF_ALLOC} ${JOB_CMD}
+
+.perf_on_tioga:
+  extends: [.perf_job]
+  stage: perf-runs
+  tags:
+    - shell
+    - tioga
+  rules:
+    - if: '$ON_TIOGA == "OFF"'
+      when: never
+    - when: on_success
+  script:
+    - flux run ${TIOGA_PERF_ALLOC} ${JOB_CMD}
+
+.perf_on_tuolumne:
+  extends: [.perf_job]
+  stage: perf-runs
+  tags:
+    - shell
+    - tuolumne
+  rules:
+    - if: '$ON_TUOLUMNE == "OFF"'
+      when: never
+    - when: on_success
+  script:
+    - flux run ${TUOLUMNE_PERF_ALLOC} ${JOB_CMD}
+
+.perf_on_lassen:
+  extends: [.perf_job]
+  stage: perf-runs
+  tags:
+    - shell
+    - lassen
+  rules:
+    - if: '$ON_LASSEN == "OFF"'
+      when: never
+    - when: on_success
+  script:
+    - lalloc ${LASSEN_PERF_ALLOC} ${JOB_CMD}


### PR DESCRIPTION
## Summary

This PR adds a new pipeline for performance jobs on any machine.

In this pipeline, jobs can run on any machine, within a dedicated, exclusive allocation which is specified by `<MACHINE>_PERF_ALLOC` and can be customized per job.

There is only one performance pipeline, whatever the number of machines to run on. Implementation suggestion is demoed in the `customization` directory.

Similarly to build_and_test pipelines, jobs are added locally by projects in the `.gitlab/jobs/performances.yml` CI yaml file.

### Notes:
Design a generic way to support performance testing in Shared CI, a perf-job template to inherit from ?
#### Constraints:
  - performance analysis requires dedicated resources to avoid interference.
  - performance analysis may not be run for every commit.
#### Consequences:
  - a dedicated CI pipeline, without ressource sharing is a better fit than adding
  a performance job to the existing pipelines.
#### Issues:
  - Shared CI is not designed for pipelines with multiple machines.
  - including all pipelines configs is not possible (e.g. machine check makes no sense here, the goal is to run after test pipeline is successful).
#### Assumptions:
  - we only run performance test after regular tests, so machine is ready, and reproducing a failure is not critical for those jobs.
#### Solution:
  - dedicated pipeline where jobs can be defined for any machine / runner.
  - dedicated ressource variable.
  - stripped out config compared to build_and_test: no reproducer, no machine check.
  - ability to customize performance jobs with template in `custom_jobs_and_variables`.

