### PR TITLE
Minor improvement to performance processing templates

### DIFF
--- a/pipelines/performances.yml
+++ b/pipelines/performances.yml
@@ -110,12 +110,17 @@ stages:
   artifacts:
     paths:
       - $PERF_ARTIFACT_DIR/
+  variables:
+    GIT_SUBMODULE_STRATEGY: none
 
 .results_reporting:
   stage: perf-reporting
   tags:
     - shell
     - oslic
+  variables:
+    GIT_STRATEGY: none
+    GIT_SUBMODULE_STRATEGY: none
 
 # More elaborate templates for specific use cases
 


### PR DESCRIPTION
Minor optimization to prevent unneeded git cloning-- The `results_processing` job may need a script in the current repo, but I doubt it would need the subrepos, and the `results_reporting` job should not need to do any git checkout