### PR TITLE
Use batch executor for performance job clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Switch performance pipeline to batch executor for automatic job cancellation.
+
 ## [v2025.12.1 - 2026-01-12 ]
 
 Patch release:

--- a/pipelines/performances.yml
+++ b/pipelines/performances.yml
@@ -29,76 +29,86 @@ stages:
   extends: [.perf_job, .custom_perf]
   stage: perf-runs
   tags:
-    - shell
+    - batch
     - dane
   rules:
     - if: '$ON_DANE == "OFF"'
       when: never
     - when: on_success
+  variables:
+    SCHEDULER_PARAMETERS: ${DANE_PERF_ALLOC}
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - srun ${DANE_PERF_ALLOC} ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_matrix:
   extends: [.perf_job, .custom_perf]
   stage: perf-runs
   tags:
-    - shell
+    - batch
     - matrix
   rules:
     - if: '$ON_MATRIX == "OFF"'
       when: never
     - when: on_success
+  variables:
+    SCHEDULER_PARAMETERS: ${MATRIX_PERF_ALLOC}
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - srun ${MATRIX_PERF_ALLOC} ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_corona:
   extends: [.perf_job, .custom_perf]
   stage: perf-runs
   tags:
-    - shell
+    - batch
     - corona
   rules:
     - if: '$ON_CORONA == "OFF"'
       when: never
     - when: on_success
+  variables:
+    SCHEDULER_PARAMETERS: ${CORONA_PERF_ALLOC}
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - srun ${CORONA_PERF_ALLOC} ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_tioga:
   extends: [.perf_job, .custom_perf]
   stage: perf-runs
   tags:
-    - shell
+    - batch
     - tioga
   rules:
     - if: '$ON_TIOGA == "OFF"'
       when: never
     - when: on_success
+  variables:
+    SCHEDULER_PARAMETERS: ${TIOGA_PERF_ALLOC}
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - flux run ${TIOGA_PERF_ALLOC} ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_tuolumne:
   extends: [.perf_job, .custom_perf]
   stage: perf-runs
   tags:
-    - shell
+    - batch
     - tuolumne
   rules:
     - if: '$ON_TUOLUMNE == "OFF"'
       when: never
     - when: on_success
+  variables:
+    SCHEDULER_PARAMETERS: ${TUOLUMNE_PERF_ALLOC}
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - flux run ${TUOLUMNE_PERF_ALLOC} ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_lassen:
   extends: [.perf_job, .custom_perf]

--- a/templates/performance-pipeline/template.yml
+++ b/templates/performance-pipeline/template.yml
@@ -127,7 +127,7 @@ stages:
 
 .on_dane:
   tags:
-    - shell
+    - batch
     - dane
   rules:
     - if: '$ON_DANE == "OFF"'
@@ -138,7 +138,7 @@ stages:
 
 .on_matrix:
   tags:
-    - shell
+    - batch
     - matrix
   rules:
     - if: '$ON_MATRIX == "OFF"'
@@ -149,7 +149,7 @@ stages:
 
 .on_corona:
   tags:
-    - shell
+    - batch
     - corona
   rules:
     - if: '$ON_CORONA == "OFF"'
@@ -160,7 +160,7 @@ stages:
 
 .on_tioga:
   tags:
-    - shell
+    - batch
     - tioga
   rules:
     - if: '$ON_TIOGA == "OFF"'
@@ -171,7 +171,7 @@ stages:
 
 .on_tuolumne:
   tags:
-    - shell
+    - batch
     - tuolumne
   rules:
     - if: '$ON_TUOLUMNE == "OFF"'
@@ -194,42 +194,52 @@ stages:
 .perf_on_dane:
   extends: [.perf_job, .on_dane, .custom_perf]
   stage: perf-runs
+  variables:
+    SCHEDULER_PARAMETERS: $[[ inputs.dane_perf_alloc ]]
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - srun $[[ inputs.dane_perf_alloc ]] ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_matrix:
   extends: [.perf_job, .on_matrix, .custom_perf]
   stage: perf-runs
+  variables:
+    SCHEDULER_PARAMETERS: $[[ inputs.matrix_perf_alloc ]]
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - srun $[[ inputs.matrix_perf_alloc ]] ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_corona:
   extends: [.perf_job, .on_corona, .custom_perf]
   stage: perf-runs
+  variables:
+    SCHEDULER_PARAMETERS: $[[ inputs.corona_perf_alloc ]]
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - srun $[[ inputs.corona_perf_alloc ]] ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_tioga:
   extends: [.perf_job, .on_tioga, .custom_perf]
   stage: perf-runs
+  variables:
+    SCHEDULER_PARAMETERS: $[[ inputs.tioga_perf_alloc ]]
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - flux run $[[ inputs.tioga_perf_alloc ]] ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_tuolumne:
   extends: [.perf_job, .on_tuolumne, .custom_perf]
   stage: perf-runs
+  variables:
+    SCHEDULER_PARAMETERS: $[[ inputs.tuolumne_perf_alloc ]]
   script:
     - export PERF_ARTIFACT_DIR=${PERF_ARTIFACT_DIR}/${CI_JOB_NAME}
     - mkdir -p ${PERF_ARTIFACT_DIR}
-    - flux run $[[ inputs.tuolumne_perf_alloc ]] ${JOB_CMD}
+    - ${JOB_CMD}
 
 .perf_on_lassen:
   extends: [.perf_job, .on_lassen, .custom_perf]

--- a/templates/performance-pipeline/template.yml
+++ b/templates/performance-pipeline/template.yml
@@ -37,7 +37,7 @@ spec:
 
     corona_perf_alloc:
       type: string
-      description: "Flux alloc arguments for job allocation on Corona"
+      description: "SLURM batch arguments for job allocation on Corona"
       default: ""
 
     tioga_perf_alloc:

--- a/templates/performance-pipeline/template.yml
+++ b/templates/performance-pipeline/template.yml
@@ -27,12 +27,12 @@ spec:
 
     dane_perf_alloc:
       type: string
-      description: "SLURM srun arguments for job allocation on Dane"
+      description: "SLURM batch arguments for job allocation on Dane"
       default: ""
 
     matrix_perf_alloc:
       type: string
-      description: "SLURM srun arguments for job allocation on Matrix"
+      description: "SLURM batch arguments for job allocation on Matrix"
       default: ""
 
     corona_perf_alloc:
@@ -42,12 +42,12 @@ spec:
 
     tioga_perf_alloc:
       type: string
-      description: "Flux alloc arguments for job allocation on Tioga"
+      description: "Flux batch arguments for job allocation on Tioga"
       default: ""
 
     tuolumne_perf_alloc:
       type: string
-      description: "Flux alloc arguments for job allocation on Tuolumne"
+      description: "Flux batch arguments for job allocation on Tuolumne"
       default: ""
 
     lassen_perf_alloc:


### PR DESCRIPTION
Improved solution from issue being addressed by https://github.com/llnl/radiuss-shared-ci/pull/66.

The current issue is if a performance job is canceled in the GitLab CI or hits the GitLab job runner time limit, then the underlying flux or slurm job does not get canceled.

This PR address this by using the [Jacamar batch executor](https://ecp-ci.gitlab.io/docs/ci-users/ci-batch.html#batch-executors) instead of shell executor. This way Jacamar itself handles submitting the batch job and cleaning it up if it is cancelled/ hits timeout.

I have tested this for components/ non-components for the case where I canceled a queued job, a running job, and had the job hit the GitLab timeout. In all cases the flux/slurm job was cleaned up automatically.